### PR TITLE
Refactor function calls to use updated module name

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,16 +9,16 @@ x_min, x_max = -10, 10  # Range of x values
 noise_level = 30  # Standard deviation of the noise
 
 # Generate synthetic polynomial data
-X, y = functions_2.generate_polynomial_data(num_samples, coefficients, x_min, x_max, noise_level)
+X, y = functions.generate_polynomial_data(num_samples, coefficients, x_min, x_max, noise_level)
 
 # Plot the generated data alongside the polynomial without noise for comparison
 x = X[:, 1]  # Extract the x values from the design matrix
 y_hat_initial = X @ np.array(coefficients).reshape(-1, 1)  # Compute the initial predictions
-functions_2.plot_data_predictions(x, y, y_hat_initial.flatten(), label_pred='Initial Prediction')
+functions.plot_data_predictions(x, y, y_hat_initial.flatten(), label_pred='Initial Prediction')
 plt.title('Data Generation with Initial Prediction')
 
 # Initialize the weights for polynomial regression model
-initial_weights = functions_2.initialize_weights(X.shape[1], zero_init=False)
+initial_weights = functions.initialize_weights(X.shape[1], zero_init=False)
 
 # Display the initial weights
 print('Initial weights shape:', initial_weights.shape)
@@ -26,11 +26,11 @@ print('Initial weights:', initial_weights)
 
 # Visualize the predictions using the initial weights
 y_hat_zero = X @ initial_weights
-functions_2.plot_data_predictions(x, y, y_hat_zero.flatten(), label_pred='Initial Model Prediction')
+functions.plot_data_predictions(x, y, y_hat_zero.flatten(), label_pred='Initial Model Prediction')
 plt.title('Initial Model Prediction')
 
 # Perform gradient descent to optimize the weights
-final_weights, error_history, epochs = functions_2.perform_gradient_descent(X, y, initial_weights)
+final_weights, error_history, epochs = functions.perform_gradient_descent(X, y, initial_weights)
 
 # Display the optimization results
 print('Final weights:', final_weights)
@@ -40,5 +40,5 @@ print('Total epochs:', epochs)
 
 # Plot the final predictions after training the model
 y_hat_final = X @ final_weights
-functions_2.plot_data_predictions(x, y, y_hat_final.flatten(), label_pred='Final Prediction')
+functions.plot_data_predictions(x, y, y_hat_final.flatten(), label_pred='Final Prediction')
 plt.title('Model Prediction After Training')


### PR DESCRIPTION
The function call was off due to the name being `functions_2` where the changed function name was `functions`.